### PR TITLE
Add support for multipackage installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .bundler/
 Berksfile.lock
 Gemfile.lock
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,27 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: ubuntu-14.04
+  - name: centos-6.6
+
+suites:
+  - name: default
+    run_list:
+      - recipe[packages]
+    attributes:
+      packages: [bash, grep]
+    provisioner:
+      require_chef_omnibus: 12.0.3
+
+  - name: multipackage
+    run_list:
+      - recipe[packages]
+    attributes:
+      packages: [bash, grep]
+    provisioner:
+      require_chef_omnibus: 12.3.0

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,0 @@
-source 'https://supermarket.getchef.com'
-
-metadata

--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ group :development do
   gem 'berkshelf'
 end
 
-# gem 'excon', '0.40.0'
-# gem 'json', '1.8.1'
+gem 'test-kitchen'
+gem 'kitchen-vagrant'

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Recipe
 default
 -------
 
-Simply loops over the contents of `node['packages']` and executes the specified action with the `package` resource.
+The recipe installs the packages specified in the `node['packages']` attribute. It will use Chef 12.1.0's "multipackage" feature if the attribute is an array.
 
 License and Author
 ==================
@@ -48,7 +48,7 @@ License and Author
 Author:: Matt Ray (<matt@getchef.com>)
 Author:: Joshua Timberman (<joshua@getchef.com>)
 
-Copyright 2013-2014 Chef Software, Inc.
+Copyright 2013-2015 Chef Software, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# There isn't an easy way to duck-type whether the package provider on
+# an arbitrary platform supports multipackage. While we know it's
+# available in Chef 12.1.0+, it is better to ask for the feature,
+# rather than ask for the Chef version.
+def multipackage_supported?
+  begin
+    Chef::Resource::Package.new([], nil).package_name([])
+    Chef::Log.debug('This version of Chef supports "multipackage"')
+    true
+  rescue Chef::Exceptions::ValidationFailed
+    Chef::Log.debug('This version of Chef does not support "multipackage"')
+    false
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,13 +19,20 @@
 
 Chef::Log.info "packages:#{node['packages'].inspect}"
 
-if node['packages'].is_a?(Array)
-  node['packages'].each do |pkg|
-    package pkg do
+case node['packages']
+when Array
+  if multipackage_supported?
+    package node['packages'] do
       action node['packages_default_action'].to_sym
     end
+  else
+    node['packages'].each do |pkg|
+      package pkg do
+        action node['packages_default_action'].to_sym
+      end
+    end
   end
-elsif node['packages'].is_a?(Hash)
+when Hash
   node['packages'].each do |pkg, act|
     package pkg.to_s do
       action act.to_sym


### PR DESCRIPTION
Chef 12.1.0 introduced "multipackage" installation, where the package
resource can take the name of packages to install as an array.

This change introduces a new library helper method,
multipackage_supported?, which returns true or false depending on
whether it's supported.

There isn't an easy way to duck-type whether the package provider on
an arbitrary platform supports multipackage. While we know it's
available in Chef 12.1.0+, it is better to ask for the feature,
rather than ask for the Chef version. As other package managers may have
support for multipackage added in the future, we want to ensure that
this works without having to do version comparisons.

This commit also adds test kitchen support, so we can check
12.0.3 where multipackage was NOT supported, and 12.3.0 (the current
release), where multipackage IS supported for the two platforms included
in the test matrix (apt on ubuntu, yum on centos).