### PR TITLE
Add guard clause in case a package list that is empty is programmatic…

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,6 +21,7 @@ Chef::Log.info "packages:#{node['packages-cookbook'].inspect}"
 
 case node['packages-cookbook']
 when Array
+  return if node['packages-cookbook'].empty?
   if multipackage_supported?
     package node['packages-cookbook'] do
       action node['packages-cookbook_default_action'].to_sym
@@ -33,6 +34,7 @@ when Array
     end
   end
 when Hash
+  return if node['packages-cookbook'].empty?
   node['packages-cookbook'].each do |pkg, act|
     package pkg.to_s do
       action act.to_sym

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -1,11 +1,11 @@
 require_relative '../spec_helper'
 
-describe 'packages::default' do
-  context 'packages attribute is an array' do
+describe 'packages::default' do # rubocop:disable BlockLength
+  context 'packages attribute is an array' do # rubocop:disable BlockLength
     context 'default action is install' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
-          node.set['packages-cookbook'] = %w(git)
+          node.set['packages-cookbook'] = [git]
         end.converge(described_recipe)
       end
 
@@ -17,19 +17,19 @@ describe 'packages::default' do
     context 'default action is install multiple' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
-          node.set['packages-cookbook'] = %w(bash openssl)
+          node.set['packages-cookbook'] = [bash, openssl]
         end.converge(described_recipe)
       end
 
       it 'installs bash and openssl' do
-        expect(chef_run).to install_package(%w(bash openssl))
+        expect(chef_run).to install_package([bash, openssl])
       end
     end
 
     context 'default action is upgrade' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
-          node.set['packages-cookbook'] = %w(git)
+          node.set['packages-cookbook'] = [git]
           node.set['packages-cookbook_default_action'] = 'upgrade'
         end.converge(described_recipe)
       end
@@ -42,13 +42,13 @@ describe 'packages::default' do
     context 'default action is upgrade multiple' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
-          node.set['packages-cookbook'] = %w(bash openssl)
+          node.set['packages-cookbook'] = [bash, openssl]
           node.set['packages-cookbook_default_action'] = 'upgrade'
         end.converge(described_recipe)
       end
 
       it 'upgrades bash and openssl' do
-        expect(chef_run).to upgrade_package(%w(bash openssl))
+        expect(chef_run).to upgrade_package([bash, openssl])
       end
     end
   end


### PR DESCRIPTION
…ally generated is added to the attribute

Signed-off-by: Scott Hain <shain@chef.io>